### PR TITLE
Visual redesign, blog, and Vercel build fix

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -623,7 +623,7 @@ nav.navbar {
 .social-icon-img {
   width: 20px;
   height: 20px;
-  filter: brightness(0) invert(0.55);
+  filter: brightness(0) invert(0.8);
   transition: filter var(--duration-fast) ease;
 }
 

--- a/src/App.css
+++ b/src/App.css
@@ -1713,34 +1713,206 @@ nav.navbar {
   padding-bottom: var(--section-padding);
 }
 
-.blog-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-  gap: 2rem;
-  margin-top: 2rem;
+/* Blog list */
+.blog-header {
+  padding: clamp(3rem, 8vw, 6rem) 0 3rem;
+  max-width: 720px;
 }
 
-.blog-card {
+.blog-header h1 {
+  font-size: clamp(2.5rem, 6vw, 4rem);
+  color: var(--text-primary);
+  margin-bottom: 0.75rem;
+}
+
+.blog-header p {
+  font-family: var(--font-display-book);
+  font-size: 1.05rem;
+  color: var(--text-secondary);
+  line-height: 1.65;
+}
+
+.blog-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  max-width: 720px;
+}
+
+.blog-card-link {
+  text-decoration: none;
+  color: inherit;
+}
+
+.blog-list-item {
+  padding: 2.5rem 0;
+  border-bottom: 1px solid var(--glass-border);
+  transition: padding-left var(--duration-base) var(--ease-premium);
+  cursor: pointer;
+}
+
+.blog-card-link:first-child .blog-list-item {
+  border-top: 1px solid var(--glass-border);
+}
+
+.blog-card-link:hover .blog-list-item {
+  padding-left: 0.75rem;
+}
+
+.blog-list-meta {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  margin-bottom: 0.75rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.post-sep {
+  color: var(--text-muted);
+}
+
+.blog-list-title {
+  font-family: var(--font-display);
+  font-size: clamp(1.25rem, 3vw, 1.75rem);
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  color: var(--text-primary);
+  margin-bottom: 0.75rem;
+  line-height: 1.15;
+  transition: color var(--duration-fast) var(--ease-premium);
+}
+
+.blog-card-link:hover .blog-list-title {
+  color: var(--accent);
+}
+
+.blog-list-excerpt {
+  font-family: var(--font-display-book);
+  font-size: 0.95rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
+  margin-bottom: 1rem;
+}
+
+/* Post tags */
+.post-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.post-tag {
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 0.2rem 0.55rem;
+  background: var(--accent-dim);
+  border: 1px solid var(--accent-border);
+  color: var(--accent);
+  border-radius: 3px;
+}
+
+/* Single post */
+.post-container {
+  max-width: 680px;
+  padding-top: clamp(3rem, 8vw, 5rem);
+  padding-bottom: var(--section-padding);
+}
+
+.post-back {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  text-decoration: none;
+  display: inline-block;
+  margin-bottom: 3rem;
+  transition: color var(--duration-fast) ease;
+}
+
+.post-back:hover {
+  color: var(--accent);
+}
+
+.post-header {
+  margin-bottom: 3rem;
+  padding-bottom: 2rem;
+  border-bottom: 1px solid var(--glass-border);
+}
+
+.post-meta {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  margin-bottom: 1.25rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.post-title {
+  font-family: var(--font-display);
+  font-size: clamp(1.75rem, 4vw, 2.75rem);
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  line-height: 1.1;
+  color: var(--text-primary);
+  margin-bottom: 1.5rem;
+}
+
+/* Post body prose */
+.post-body {
+  font-family: var(--font-display-book);
+  font-size: 1.05rem;
+  line-height: 1.8;
+  color: var(--text-secondary);
+}
+
+.post-body p {
+  margin-bottom: 1.5rem;
+  color: var(--text-secondary);
+}
+
+.post-body h2 {
+  font-family: var(--font-display);
+  font-size: 1.25rem;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  color: var(--text-primary);
+  margin-top: 2.5rem;
+  margin-bottom: 0.75rem;
+  line-height: 1.2;
+}
+
+.post-body hr {
+  border: none;
+  border-top: 1px solid var(--glass-border);
+  margin: 3rem 0;
+}
+
+.post-body code {
+  font-family: var(--font-mono);
+  font-size: 0.875em;
   background: var(--glass-bg);
   border: 1px solid var(--glass-border);
-  border-radius: var(--card-radius);
-  overflow: hidden;
-  transition:
-    transform var(--duration-base) var(--ease-premium),
-    box-shadow var(--duration-base) var(--ease-premium),
-    border-color var(--duration-base) var(--ease-premium);
-}
-
-.blog-card:hover {
-  transform: translateY(-5px);
-  box-shadow: var(--glass-glow), var(--glass-shadow);
-  border-color: var(--glass-border-accent);
+  border-radius: 4px;
+  padding: 0.1em 0.4em;
+  color: var(--accent);
 }
 
 @media (max-width: 768px) {
-  .blog-grid {
-    grid-template-columns: 1fr;
-    gap: 1.5rem;
+  .blog-list-item {
+    padding: 2rem 0;
+  }
+
+  .post-body {
+    font-size: 1rem;
   }
 }
 

--- a/src/App.js
+++ b/src/App.js
@@ -6,6 +6,7 @@ import { Routes, Route } from 'react-router-dom';
 import Home from './pages/Home';
 import Development from './pages/Development';
 import Blog from './pages/Blog';
+import BlogPost from './pages/BlogPost';
 import { About } from './components/About';
 import MediaSection from './components/MediaSection';
 import { Projects } from './components/Projects';
@@ -20,6 +21,7 @@ function App() {
         <Route path="/development" element={<Development />} />
         <Route path="/media" element={<MediaSection />} />
         <Route path="/blog" element={<Blog />} />
+        <Route path="/blog/:slug" element={<BlogPost />} />
         <Route path="/about" element={<About />} />
       </Routes>
       <Footer/>

--- a/src/components/Banner.js
+++ b/src/components/Banner.js
@@ -32,7 +32,7 @@ export const Banner = () => {
                 transition={{ duration: 1, delay: 0.2 }}
               >
                 I build<br/>
-                backend systems<br/>
+                systems<br/>
                 <span className="accent-text">end-to-end.</span>
               </motion.h1>
 

--- a/src/components/Skills.js
+++ b/src/components/Skills.js
@@ -1,6 +1,6 @@
 import { Container } from 'react-bootstrap'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faPython, faGitAlt, faJsSquare, faHtml5, faCss3Alt, faReact, faNodeJs, faConnectdevelop, faFigma, faMicrosoft } from '@fortawesome/free-brands-svg-icons';
+import { faPython, faGitAlt, faJsSquare, faHtml5, faCss3Alt, faReact, faNodeJs, faConnectdevelop, faFigma } from '@fortawesome/free-brands-svg-icons';
 import { faServer, faCode, faDatabase, faFlask, faRocket, faBook, faMagnifyingGlassChart, faChartLine, faCube, faTerminal, faGears, faWandMagicSparkles, faCloud } from '@fortawesome/free-solid-svg-icons';
 import Carousel from "react-multi-carousel";
 import "react-multi-carousel/lib/styles.css";

--- a/src/data/posts.js
+++ b/src/data/posts.js
@@ -1,7 +1,7 @@
 export const posts = [
   {
     slug: 'stop-burning-tokens',
-    title: "You're burning tokens without knowing it",
+    title: "Avoid token burn",
     date: 'March 2026',
     readTime: '4 min',
     excerpt: "More context doesn't always mean better results. Some habits that actually cost you when using Claude.",

--- a/src/data/posts.js
+++ b/src/data/posts.js
@@ -1,0 +1,10 @@
+export const posts = [
+  {
+    slug: 'stop-burning-tokens',
+    title: "You're burning tokens without knowing it",
+    date: 'March 2026',
+    readTime: '4 min',
+    excerpt: "More context doesn't always mean better results. Some habits that actually cost you when using Claude.",
+    tags: ['claude', 'llm', 'productivity'],
+  }
+];

--- a/src/pages/Blog.js
+++ b/src/pages/Blog.js
@@ -1,19 +1,46 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
+import { motion } from 'framer-motion';
+import { posts } from '../data/posts';
 
 function Blog() {
   return (
-    <div className="blog-page">
-      <section className="project">
-        <div className="container">
-          <div className="project-bx">
-            <h2>Blog</h2>
-            <p>Sharing thoughts on development, design, and technology.</p>
-            {/* Blog content will go here */}
-          </div>
+    <motion.div
+      className="blog-page"
+      initial={{ opacity: 0, y: 24 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.6 }}
+    >
+      <div className="container">
+        <div className="blog-header">
+          <span className="label-mono">Writing</span>
+          <h1>Blog</h1>
+          <p>Occasional writing on software, tooling, and things I've had to figure out.</p>
         </div>
-      </section>
-    </div>
+
+        <div className="blog-list">
+          {posts.map(post => (
+            <Link key={post.slug} to={`/blog/${post.slug}`} className="blog-card-link">
+              <article className="blog-list-item">
+                <div className="blog-list-meta">
+                  <span className="post-date">{post.date}</span>
+                  <span className="post-sep">·</span>
+                  <span className="post-read-time">{post.readTime} read</span>
+                </div>
+                <h2 className="blog-list-title">{post.title}</h2>
+                <p className="blog-list-excerpt">{post.excerpt}</p>
+                <div className="post-tags">
+                  {post.tags.map(tag => (
+                    <span key={tag} className="post-tag">{tag}</span>
+                  ))}
+                </div>
+              </article>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </motion.div>
   );
 }
 
-export default Blog; 
+export default Blog;

--- a/src/pages/BlogPost.js
+++ b/src/pages/BlogPost.js
@@ -1,0 +1,130 @@
+import React from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { motion } from 'framer-motion';
+import { posts } from '../data/posts';
+
+const postContent = {
+  'stop-burning-tokens': {
+    body: (
+      <>
+        <p>
+          Most people who use Claude figure that longer prompts are better. More context, more
+          examples, more explanation — more for the AI to work with.
+        </p>
+        <p>I used to think this too. I was wrong about it pretty consistently.</p>
+        <p>
+          The context window is basically how much text Claude can hold in its head at once, and
+          it's finite. In a long conversation, older stuff gets compressed or dropped. But more
+          relevantly: everything you add gets processed. A big rambling system prompt before a
+          simple question means a lot of that processing goes toward noise.
+        </p>
+        <p>Some things I've noticed that actually cost you:</p>
+
+        <h2>Repeating context that's already there</h2>
+        <p>
+          If you're five messages in and you're writing "as I mentioned, this is a TypeScript
+          project..." you're either burning tokens on something Claude already knows, or you never
+          set up the context cleanly. Put it up front once.
+        </p>
+
+        <h2>Pasting the whole file when you need one function</h2>
+        <p>
+          You probably know where the bug is. If you're dumping an 800-line file and asking Claude
+          to find the issue in the auth handler, you already know it's in the auth handler. Paste
+          that part.
+        </p>
+
+        <h2>Trying to nail it in one massive prompt</h2>
+        <p>
+          The instinct is to front-load everything Claude might possibly need, because you want to
+          get the answer right the first time. A focused three-message exchange usually works better
+          and uses less context than one sprawling attempt to anticipate everything. Say the problem,
+          see what comes back, adjust.
+        </p>
+
+        <h2>Keeping a conversation alive past the point where it's useful</h2>
+        <p>
+          Long sessions accumulate junk: abandoned approaches, wrong assumptions, corrections to
+          corrections. All still in the context, influencing responses in ways you can't fully see.
+          If a session has gone sideways twice, starting over with a cleaner prompt is usually faster
+          than trying to fix it in place.
+        </p>
+
+        <h2>Asking Claude to figure out the problem instead of telling it what the problem is</h2>
+        <p>
+          "What should I do about my database schema?" is expensive. "My users table has 40M rows
+          and queries are hitting 800ms — should I add a partial index on status or partition by
+          date?" is cheap. Do enough thinking to get to the actual decision point first, then ask
+          about that specific thing.
+        </p>
+
+        <hr />
+
+        <p>
+          None of this is about being terse for its own sake. It's about not burying what actually
+          matters under everything that doesn't.
+        </p>
+        <p>
+          If you're on Claude Code, your token count is visible in the session. If a conversation is
+          at 80k tokens and you're still going in circles, just start a new one. Fresh context
+          consistently produces better results than trying to repair a long conversation that went
+          off course.
+        </p>
+      </>
+    ),
+  },
+};
+
+function BlogPost() {
+  const { slug } = useParams();
+  const meta = posts.find(p => p.slug === slug);
+  const content = postContent[slug];
+
+  if (!meta || !content) {
+    return (
+      <div className="blog-page">
+        <div className="container">
+          <p style={{ color: 'var(--text-secondary)', paddingTop: '8rem' }}>Post not found.</p>
+          <Link to="/blog" className="btn-secondary" style={{ marginTop: '1rem', display: 'inline-flex' }}>
+            Back to blog
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <motion.div
+      className="blog-page"
+      initial={{ opacity: 0, y: 24 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.6 }}
+    >
+      <div className="container">
+        <div className="post-container">
+          <Link to="/blog" className="post-back">← Blog</Link>
+
+          <header className="post-header">
+            <div className="post-meta">
+              <span className="post-date">{meta.date}</span>
+              <span className="post-sep">·</span>
+              <span className="post-read-time">{meta.readTime} read</span>
+            </div>
+            <h1 className="post-title">{meta.title}</h1>
+            <div className="post-tags">
+              {meta.tags.map(tag => (
+                <span key={tag} className="post-tag">{tag}</span>
+              ))}
+            </div>
+          </header>
+
+          <article className="post-body">
+            {content.body}
+          </article>
+        </div>
+      </div>
+    </motion.div>
+  );
+}
+
+export default BlogPost;


### PR DESCRIPTION
## Summary
- Redesigns site with amber/gold design system on near-monochrome base (#080808), replacing the previous purple→cyan gradient. CentraNo2 typography, glassmorphism cards, new hero copy with split portrait layout
- Adds blog with first post: \"You're burning tokens without knowing it\" — slug-based routing (`/blog/:slug`), post list and single-post pages
- Fixes Vercel CI build failure caused by unused `faMicrosoft` import in Skills.js (warnings treated as errors under `CI=true`)

## Test plan
- [ ] Home page renders with amber accent, hero portrait visible and not covered by text
- [ ] `/blog` lists the post with date, read time, excerpt, and tags
- [ ] `/blog/stop-burning-tokens` renders the full post
- [ ] Vercel build deploys cleanly (no ESLint warnings)
- [ ] Nav, projects, skills, about, footer all render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)